### PR TITLE
fix for issues #44, #46, and #47

### DIFF
--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1537,8 +1537,8 @@ def pprint(data, names='', title='', formats={}):
         print(' '.join(key.rjust(str_lengths[key]) for key in pdata.keys()))
         print(' '.join('-' * str_lengths[key] for key in pdata.keys()))
         for i in range(len(pdata)):
-            print(' '.join(str(pdata[key].data[0]).decode('utf-8')[:max_length].rjust(str_lengths[key])
-                           if pdata[key].data[0] is not None else '-'.rjust(str_lengths[key])
+            print(' '.join(str(pdata[key].data[i]).decode('utf-8')[:max_length].rjust(str_lengths[key])
+                           if pdata[key].data[i] is not None else '-'.rjust(str_lengths[key])
                            for key in pdata.keys()))
 
 

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -264,14 +264,29 @@ class Database:
 
         while any(duplicate):
             # Pull out duplicates one by one
-            SQL = "SELECT t1.id, t2.id FROM {0} t1 JOIN {0} t2 ON t1.source_id=t2.source_id WHERE t1.id!=t2.id AND {1}{2}{3}" \
-                .format(table, ' AND '.join(['t1.{0}=t2.{0}'.format(i) for i in req_keys]), (' AND ' \
-                                                                                             + ' AND '.join(
-                    ["(t1.id NOT IN ({0}) and t2.id NOT IN ({0}))".format(','.join(map(str, [id1, id2]))) for id1, id2 \
-                     in zip(ignore['id1'], ignore['id2'])])) if any(ignore) else '', (' AND ' \
-                                                                                      + ' AND '.join(
-                    ["(t1.id NOT IN ({0}) and t2.id NOT IN ({0}))".format(','.join(map(str, ni))) for ni \
-                     in new_ignore])) if new_ignore else '')
+            if table.lower() != 'sources':
+                SQL = "SELECT t1.id, t2.id FROM {0} t1 JOIN {0} t2 ON t1.source_id=t2.source_id " \
+                      "WHERE t1.id!=t2.id AND {1}{2}{3}"\
+                    .format(table,
+                            ' AND '.join(['t1.{0}=t2.{0}'.format(i) for i in req_keys]),
+                            (' AND ' + ' AND '.join(["(t1.id NOT IN ({0}) and t2.id NOT IN ({0}))"
+                                                    .format(','.join(map(str, [id1, id2]))) for id1, id2
+                                                     in zip(ignore['id1'], ignore['id2'])]))
+                                              if any(ignore) else '',
+                            (' AND ' + ' AND '.join(["(t1.id NOT IN ({0}) and t2.id NOT IN ({0}))"
+                                                    .format(','.join(map(str, ni))) for ni in new_ignore]))
+                                              if new_ignore else '')
+            else:
+                SQL = "SELECT t1.id, t2.id FROM {0} t1 JOIN {0} t2 ON t1.id=t2.id WHERE {1}{2}{3}" \
+                    .format(table,
+                            ' AND '.join(['t1.{0}=t2.{0}'.format(i) for i in req_keys]),
+                            (' AND ' + ' AND '.join(["(t1.id NOT IN ({0}) and t2.id NOT IN ({0}))"
+                                                    .format(','.join(map(str, [id1, id2]))) for id1, id2
+                                                     in zip(ignore['id1'], ignore['id2'])]))
+                            if any(ignore) else '',
+                            (' AND ' + ' AND '.join(["(t1.id NOT IN ({0}) and t2.id NOT IN ({0}))"
+                                                    .format(','.join(map(str, ni))) for ni in new_ignore]))
+                            if new_ignore else '')
 
             duplicate = self.query(SQL, fetch='one')
 

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1402,7 +1402,7 @@ def convert_spectrum(File):
         return spectrum
 
 
-def __create_waxis(fitsHeader, lenData, fileName, wlog=False):
+def __create_waxis(fitsHeader, lenData, fileName, wlog=False, verb=True):
     # Define key names in
     KEY_MIN = ['COEFF0', 'CRVAL1']  # Min wl
     KEY_DELT = ['COEFF1', 'CDELT1', 'CD1_1']  # Delta of wl
@@ -1442,7 +1442,7 @@ def __create_waxis(fitsHeader, lenData, fileName, wlog=False):
     return wAxis
 
 
-def __get_spec(fitsData, fitsHeader, fileName):
+def __get_spec(fitsData, fitsHeader, fileName, verb=True):
     validData = [None] * 3
 
     # Identify number of data sets in fits file

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -264,7 +264,7 @@ class Database:
 
         while any(duplicate):
             # Pull out duplicates one by one
-            if table.lower() in ['sources', 'publications']:
+            if 'source_id' not in columns:  # Check if there is a source_id in the columns
                 SQL = "SELECT t1.id, t2.id FROM {0} t1 JOIN {0} t2 ON t1.id=t2.id WHERE {1}{2}{3}" \
                     .format(table,
                             ' AND '.join(['t1.{0}=t2.{0}'.format(i) for i in req_keys]),


### PR DESCRIPTION
A quick fix during merging clean up that tests if the table is 'sources' or 'publications'. If so, it doesn't look for a source_id column and matches instead by id. It also fixes a hanging WHERE in the SQL text if there are no required keys, ignored objects, etc. This should fix the merging issues for both the sources and publications tables.