### PR TITLE
Merging build_db changes and moving to 0.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
     - 2.7
-    - 3.3
     - 3.4
     - 3.5
 
@@ -28,9 +27,9 @@ env:
         # Try all python versions with the latest numpy
         - SETUP_CMD='py.test'
 
-matrix:
-    allow_failures:
-        - python: 3.3
+#matrix:
+#    allow_failures:
+#        - python: 3.3
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/astrodbkit/__init__.py
+++ b/astrodbkit/__init__.py
@@ -1,2 +1,2 @@
 from pkg_resources import get_distribution
-__version__ = '0.5.2'
+__version__ = '0.6.0'

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -2027,6 +2027,3 @@ def _autofill_spec_record(record):
 
 type_dict = {'INTEGER': np.dtype('int64'), 'REAL': np.dtype('float64'), 'TEXT': np.dtype('object'),
              'ARRAY': np.dtype('object'), 'SPECTRUM': np.dtype('object'), 'BOOLEAN': np.dtype('bool')}
-# TODO: Consider dtype of object for TEXT/SPECTRUM fields
-# type_dict = {'INTEGER': np.dtype('int64'), 'REAL': np.dtype('float64'), 'TEXT': np.dtype('S128'),
-#              'ARRAY': np.dtype('object'), 'SPECTRUM': np.dtype('S256'), 'BOOLEAN': np.dtype('bool')}

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1873,8 +1873,8 @@ sqlite3.register_adapter(np.ndarray, adapt_array)
 # sqlite3.register_adapter(str, adapt_spectrum)
 
 # Register the converters
-sqlite3.register_converter("ARRAY", convert_array)
-sqlite3.register_converter("SPECTRUM", convert_spectrum)
+sqlite3.register_converter(str("ARRAY"), convert_array)
+sqlite3.register_converter(str("SPECTRUM"), convert_spectrum)
 
 
 def pprint(data, names='', title='', formats={}):

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1086,7 +1086,8 @@ class Database:
         params: sequence
             Mimics the native parameter substitution of sqlite3
         fmt: str
-            Returns the data as a dictionary, array, or astropy.table given 'dict', 'array', or 'table'
+            Returns the data as a dictionary, array, astropy.table, or pandas.Dataframe
+            given 'dict', 'array', 'table', or 'pandas'
         fetch: str
             String indicating whether to return **all** results or just **one**
         unpack: bool
@@ -1147,9 +1148,17 @@ class Database:
 
                     # Or return the results
                     else:
-                        if fetch == 'one': dictionary, array = dictionary[0], array if unpack else np.array(
-                            list(array[0]))
-                        return table if fmt == 'table' else dictionary if fmt == 'dict' else array
+                        if fetch == 'one':
+                            dictionary, array = dictionary[0], array if unpack else np.array(list(array[0]))
+
+                        if fmt == 'table':
+                            return table
+                        elif fmt == 'dict':
+                            return dictionary
+                        elif fmt == 'pandas':
+                            return table.to_pandas()
+                        else:
+                            return array
 
                 else:
                     return

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1531,7 +1531,7 @@ def adapt_array(arr):
     """
     out = io.BytesIO()
     np.save(out, arr), out.seek(0)
-    return buffer(out.read())
+    return buffer(out.read())  # TODO: Fix for Python 3
 
 
 def convert_array(array):
@@ -1866,9 +1866,10 @@ def pprint(data, names='', title='', formats={}):
             print(' '.join([str(i[key]).decode('utf-8')[:max_length].rjust(str_lengths[key])
                            if i[key] else '-'.rjust(str_lengths[key]) for key in pdata.keys()]))
 
+
 def clean_header(header):
     try:
-        header = pf.open(File, ignore_missing_end=True)[0].header
+        header = pf.open(File, ignore_missing_end=True)[0].header  # TODO: Fix missing File reference
         new_header = pf.Header()
         for x, y, z in header.cards: new_header[x.replace('.', '_').replace('#', '')] = (y, z)
         header = pf.PrimaryHDU(header=new_header).header
@@ -1897,8 +1898,9 @@ def _help():
 
 def scrub(data, units=False):
     """
-    For input data [w,f,e] or [w,f] returns the list with NaN, negative, and zero flux (and corresponsing wavelengths and errors) removed.
-        """
+    For input data [w,f,e] or [w,f] returns the list with NaN, negative, and zero flux
+    (and corresponding wavelengths and errors) removed.
+    """
     units = [i.unit if hasattr(i, 'unit') else 1 for i in data]
     data = [np.asarray(i.value if hasattr(i, 'unit') else i, dtype=np.float32) for i in data if
             isinstance(i, np.ndarray)]
@@ -2023,5 +2025,8 @@ def _autofill_spec_record(record):
     return record
 
 
-type_dict = {'INTEGER': np.dtype('int64'), 'REAL': np.dtype('float64'), 'TEXT': np.dtype('S128'),
-             'ARRAY': np.dtype('object'), 'SPECTRUM': np.dtype('S256'), 'BOOLEAN': np.dtype('bool')}
+type_dict = {'INTEGER': np.dtype('int64'), 'REAL': np.dtype('float64'), 'TEXT': np.dtype('object'),
+             'ARRAY': np.dtype('object'), 'SPECTRUM': np.dtype('object'), 'BOOLEAN': np.dtype('bool')}
+# TODO: Consider dtype of object for TEXT/SPECTRUM fields
+# type_dict = {'INTEGER': np.dtype('int64'), 'REAL': np.dtype('float64'), 'TEXT': np.dtype('S128'),
+#              'ARRAY': np.dtype('object'), 'SPECTRUM': np.dtype('S256'), 'BOOLEAN': np.dtype('bool')}

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -306,7 +306,7 @@ class Database:
             self.list("DROP TABLE TempOldTable_foreign")
 
             if verbose:
-                print('Successfully added foreign key.')
+                # print('Successfully added foreign key.')
                 t = self.query('SELECT name, sql FROM sqlite_master', fmt='table')
                 print(t[t['name'] == table]['sql'][0].replace(',', ',\n'))
 
@@ -606,6 +606,20 @@ class Database:
 
         except:
             return SQL, ''
+
+    def info(self):
+        """
+        Prints out information for the loaded database, namely the available tables and the number of entries for each.
+        """
+        t = self.query("SELECT * FROM sqlite_master WHERE type='table'", fmt='table')
+        all_tables = t['name'].tolist()
+        print('Database Inventory')
+        print('==================')
+        for table in ['sources'] + [t for t in all_tables if
+                                    t not in ['sources', 'sqlite_sequence']]:
+            x = self.query('select count() from {}'.format(table), fmt='array', fetch='one')
+            if x is None: continue
+            print('{}: {}'.format(table.upper(), x[0]))
 
     def inventory(self, source_id, fetch=False, fmt='table'):
         """
@@ -1382,7 +1396,7 @@ class Database:
         pk: string or list
             Name(s) of the primary key(s) if other than ID
         new_table: bool
-                Create a new table
+            Create a new table
 
         """
         goodtogo = True

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -140,6 +140,8 @@ class Database:
 
     def __repr__(self):
         self.info()
+        print("\nFor a quick summary of how to use astrodb.Database, type db.help(), \n"
+              "where 'db' corresponds to the name of the astrodb.Database instance.")
         return ''
 
     def add_data(self, data, table, delimiter='|', bands='', verbose=False):
@@ -669,9 +671,28 @@ class Database:
 
     def help(self):
         """
-        See some brief instructions on how to use astrodb.Database
+        See a quick summary of the most useful methods in astrodb.Database
         """
-        # TODO: Write a brief help file here
+
+        helptext = """
+The astrodb.Database class, hereafter db, provides a variety of methods to interact with a SQLite database file.
+Docstrings are available for all methods and can be accessed in the usual manner; eg, help(db.query).
+We list a few key methods below.
+
+    * db.query() - send SELECT commands to the database. Returns results in a variety of formats
+    * db.add_data() - add data to an existing table, either by providing a file or by providing the data itself
+    * db.table() - create or modify tables in the database
+    * db.modify() - send more general SQL commands to the database
+    * db.info() - get a quick summary of the contents of the database
+    * db.schema() - quickly examine the columns, types, etc of a specified table
+    * db.search() - search through a table to find entries matching the criteria
+    * db.references() - search for all entries in all tables matching the criteria. Useful for publication
+    * db.save() - export a copy of the database in ascii format, which can then be re-populated by astrodb.Database
+    * db.close() - close the database connection, will prompt to save and to delete the binary database file
+
+The full documentation can be found online at: http://astrodbkit.readthedocs.io/en/latest/index.html
+        """
+        print(helptext)
 
     def info(self):
         """
@@ -679,7 +700,7 @@ class Database:
         """
         t = self.query("SELECT * FROM sqlite_master WHERE type='table'", fmt='table')
         all_tables = t['name'].tolist()
-        print('Database file: {} \nSQL: {}\n'.format(self.dbpath, self.sqlpath))
+        print('\nDatabase path: {} \nSQL path: {}\n'.format(self.dbpath, self.sqlpath))
         print('Database Inventory')
         print('==================')
         for table in ['sources'] + [t for t in all_tables if
@@ -705,7 +726,7 @@ class Database:
         Returns
         -------
         data_tables: dict
-                Returns a dictionary of astropy tables with the table name as the keys.
+            Returns a dictionary of astropy tables with the table name as the keys.
 
         """
         data_tables = {}

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -138,6 +138,10 @@ class Database:
         else:
             raise AttributeError("Sorry, no such file '{}'".format(dbpath))
 
+    def __repr__(self):
+        self.info()
+        return ''
+
     def add_data(self, data, table, delimiter='|', bands='', verbose=False):
         """
     Adds data to the specified database table. Column names must match table fields to insert,
@@ -663,12 +667,19 @@ class Database:
         except:
             return SQL, ''
 
+    def help(self):
+        """
+        See some brief instructions on how to use astrodb.Database
+        """
+        # TODO: Write a brief help file here
+
     def info(self):
         """
         Prints out information for the loaded database, namely the available tables and the number of entries for each.
         """
         t = self.query("SELECT * FROM sqlite_master WHERE type='table'", fmt='table')
         all_tables = t['name'].tolist()
+        print('Database file: {} \nSQL: {}\n'.format(self.dbpath, self.sqlpath))
         print('Database Inventory')
         print('==================')
         for table in ['sources'] + [t for t in all_tables if

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -2,6 +2,11 @@
 # encoding: utf-8
 # Author: Joe Filippazzo, jcfilippazzo@gmail.com
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
 import io
 import os
 import sys
@@ -49,20 +54,6 @@ def create_database(dbpath):
 
 
 class Database:
-    """
-    Initialize the database.
-
-    Parameters
-    ----------
-    dbpath: str
-        The path to the database file.
-
-    Returns
-    -------
-    object
-        The database object
-    """
-
     def __init__(self, dbpath):
         """
         Initialize the database.
@@ -107,8 +98,10 @@ class Database:
             # Activate foreign key support
             self.list('PRAGMA foreign_keys=ON')
 
+            print("Database ready for use")
+
         else:
-            print("Sorry, no such file '{}'".format(dbpath))
+            raise AttributeError("Sorry, no such file '{}'".format(dbpath))
 
     def add_data(self, data, table, delimiter='|', bands='', verbose=False):
         """
@@ -1121,7 +1114,7 @@ class Database:
             The result of the database query
         """
         try:
-            # Restricy queries to SELECT and PRAGMA statements
+            # Restrict queries to SELECT and PRAGMA statements
             if SQL.lower().startswith('select') or SQL.lower().startswith('pragma'):
 
                 # Make the query explicit so that column and table names are preserved
@@ -1626,6 +1619,7 @@ def convert_array(array):
     return np.load(out)
 
 
+# TODO: Eliminate this, not being used anymore
 def adapt_spectrum(spec):
     """
     Adapts a SPECTRUM object into a string to put into the database

--- a/astrodbkit/tests/test_astrodb.py
+++ b/astrodbkit/tests/test_astrodb.py
@@ -1,10 +1,9 @@
 import pytest
 import tempfile
-import os, sys
+import os
 from astropy.utils.data import download_file
 from .. import astrodb
 from sqlite3 import IntegrityError
-import io
 
 filename = os.path.join(tempfile.mkdtemp(), 'empty_db.db')
 

--- a/astrodbkit/tests/test_astrodb.py
+++ b/astrodbkit/tests/test_astrodb.py
@@ -152,3 +152,17 @@ def test_references():
     t = bdnyc_db.query('SELECT id FROM publications', fmt='table')
     id = t['id'][0]
     bdnyc_db.references(id, column_name='publication_id')
+
+
+def test_save():
+    empty_db.save(directory='tempempty')
+    bdnyc_db.save(directory='tempdata')
+
+
+def test_close(monkeypatch):
+    # Fake user input
+    inputs = ['n', 'n']
+    input_generator = (i for i in inputs)
+    monkeypatch.setattr('astrodbkit.astrodb.get_input', lambda prompt: next(input_generator))
+
+    bdnyc_db.close()


### PR DESCRIPTION
A number of changes and additions, including:

- astrodb.Database() now takes either a .db or .sql file (assumes .db if the filename does not end in either). If an .sql file, the database is generating from ascii tables stored in the specified directory (default: tabledata/). This changes the workflow to allow version controlling the individual ascii tables rather than the binary .db file.
- there is a new save() method to output the .sql file along with all the data in the database to the specified directory
- there is a modified close() method that prior to closing asks to save the database and delete the .db file
- SQL TEXT fields are treated as numpy.dtype objects rather than strings to avoid trunctation
- query() method now has a fmt='pandas' option to return the results in pandas DataFrame format
- the new info() method displays basic information on the loaded database (ie, the tables present and the number of entries in each)
- the new snapshot() method produces a snapshot of the database, useful for extracting published versions of the database