### PR TITLE
Fix for unicode characters when saving tables

### DIFF
--- a/astrodbkit/__init__.py
+++ b/astrodbkit/__init__.py
@@ -1,2 +1,2 @@
 from pkg_resources import get_distribution
-__version__ = '0.6.0'
+__version__ = '0.6.1'

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1373,13 +1373,12 @@ The full documentation can be found online at: http://astrodbkit.readthedocs.io/
             tablepaths.append(tablepath)
             with open(tablepath, 'w') as f:
                 for line in self.conn.iterdump():
-                    if sys.version_info.major == 2:
-                        # line = line.decode('utf-8')
-                        line = line.encode('utf-8').decode('utf-8')
-
                     line = line.strip()
                     if line.startswith('INSERT INTO "{}"'.format(table)):
-                        f.write('%s\n' % line.encode('ascii', 'ignore'))
+                        if sys.version_info.major == 2:
+                            f.write(u'{}\n'.format(line).encode('utf-8'))
+                        else:
+                            f.write(u'{}\n'.format(line))
 
         print("Tables saved to directory {}/".format(directory))
         print("""=======================================================================================


### PR DESCRIPTION
Fix for major bug in version 0.6 when attempting to save the database. Special characters were being silently dropped, which altered the database contents. These now are retained as the files are saved in utf-8 encoding. Tested for both Python 2.7 and 3.5.