### PR TITLE
Minor additions and fixes

### DIFF
--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1949,9 +1949,9 @@ def convert_spectrum(File, verbose=False):
                 tempwav = __create_waxis(header, len(spectrum[1]), File)
 
                 # Check to see if it's a FIRE spectrum with CDELT1, if so needs wlog=True
-                if 'INSTRUME' in header.keys():
-                    if header['INSTRUME']=='FIRE' and 'CDELT1' in header.keys():
-                        tempwav = __create_waxis(header, len(spectrum[1]), File, wlog=True)
+                # if 'INSTRUME' in header.keys():
+                #     if header['INSTRUME']=='FIRE' and 'CDELT1' in header.keys():
+                #         tempwav = __create_waxis(header, len(spectrum[1]), File, wlog=True)
 
                 spectrum[0] = tempwav
 

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1949,9 +1949,9 @@ def convert_spectrum(File, verbose=False):
                 tempwav = __create_waxis(header, len(spectrum[1]), File)
 
                 # Check to see if it's a FIRE spectrum with CDELT1, if so needs wlog=True
-                # if 'INSTRUME' in header.keys():
-                #     if header['INSTRUME']=='FIRE' and 'CDELT1' in header.keys():
-                #         tempwav = __create_waxis(header, len(spectrum[1]), File, wlog=True)
+                if 'INSTRUME' in header.keys():
+                    if header['INSTRUME'] == 'FIRE' and 'CDELT1' in header.keys():
+                        tempwav = __create_waxis(header, len(spectrum[1]), File, wlog=True)
 
                 spectrum[0] = tempwav
 

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -809,7 +809,7 @@ The full documentation can be found online at: http://astrodbkit.readthedocs.io/
                                 "SELECT {} FROM {} WHERE {}={}".format(','.join(columns), table, id, source_id), \
                                 fetch=True, fmt=fmt)
                         else:
-                            data = data[list(columns)]
+                            data = data[[c.lower() for c in columns]]
                             pprint(data, title=table.upper())
 
                 else:
@@ -1377,7 +1377,7 @@ The full documentation can be found online at: http://astrodbkit.readthedocs.io/
                         "SELECT {} FROM {} WHERE {}='{}'".format(
                             ','.join(columns), table, column_name, criteria), fmt='table', fetch=True)
                 else:
-                    data = data[list(columns)]
+                    data = data[[c.lower() for c in columns]]  # force lowercase since astropy.Tables have all lowercase
                     pprint(data, title=table.upper())
 
         if fetch: return data_tables

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1950,7 +1950,7 @@ def convert_spectrum(File, verbose=False):
 
                 # Check to see if it's a FIRE spectrum with CDELT1, if so needs wlog=True
                 if 'INSTRUME' in header.keys():
-                    if header['INSTRUME'] == 'FIRE' and 'CDELT1' in header.keys():
+                    if header['INSTRUME'].strip() == 'FIRE' and 'CDELT1' in header.keys():
                         tempwav = __create_waxis(header, len(spectrum[1]), File, wlog=True)
 
                 spectrum[0] = tempwav

--- a/astrodbkit/tests/test_astrodb.py
+++ b/astrodbkit/tests/test_astrodb.py
@@ -154,6 +154,12 @@ def test_references():
     bdnyc_db.references(id, column_name='publication_id')
 
 
+@pytest.mark.xfail
+def test_get_bibtex():
+    bdnyc_db.get_bibtex(52)
+    bdnyc_db.get_bibtex('Cruz03')
+
+
 def test_save():
     empty_db.save(directory='tempempty')
     bdnyc_db.save(directory='tempdata')


### PR DESCRIPTION
The new get_bibtex() method will return the bibtex from ADS for the specified entry in the PUBLICATIONS table. This can be used to quickly build up your bibtex file for your papers.

Added a very simple fix for the FIRE spectra. Many are already fine, but some had logarithmic wavelength scales. To find out which is which, I look for the INSTRUME (needs to be FIRE) and CDELT1 keys in the header, since these are both set in the problematic spectra. Other, already valid, FIRE spectra had INSTR keys instead and no CDELT1.

Fixed a minor bug that prevented tables like PROPER_MOTIONS from being displayed in db.references() or db.inventory(). The issue was that astropy Table column names are all lower case.