### PR TITLE
Various changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ env:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - pip install requests
 
 script:
     - $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - 2.7
     - 3.4
     - 3.5
+    - 3.6
 
 before_script:
   - "export DISPLAY=:99.0" # xvfb is used to ensure matplotlib plots don't fail
@@ -27,9 +28,9 @@ env:
         # Try all python versions with the latest numpy
         - SETUP_CMD='py.test'
 
-#matrix:
-#    allow_failures:
-#        - python: 3.3
+matrix:
+    allow_failures:
+        - python: 3.4
 
 install:
     - git clone git://github.com/astropy/ci-helpers.git

--- a/astrodbkit/__init__.py
+++ b/astrodbkit/__init__.py
@@ -1,2 +1,2 @@
 from pkg_resources import get_distribution
-__version__ = '0.6.3'
+__version__ = '0.6.4'

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -95,7 +95,10 @@ class Database:
 
                 # Then load the table data...
                 print('Populating database...')
-                tables = os.popen('sqlite3 {} ".tables"'.format(self.dbpath)).read().replace('\n',' ').split()
+                # Grabbing only tables, not tables and views
+                # tables = os.popen('sqlite3 {} ".tables"'.format(self.dbpath)).read().replace('\n',' ').split()
+                tables = os.popen("""echo "SELECT name FROM sqlite_master WHERE type='table';" | sqlite3 {}"""
+                                  .format(self.dbpath)).read().replace('\n',' ').split()
                 for table in tables:
                     print('Loading {}'.format(table))
                     os.system('sqlite3 {0} ".read {1}/{2}.sql"'.format(self.dbpath, directory, table))
@@ -1314,10 +1317,14 @@ The full documentation can be found online at: http://astrodbkit.readthedocs.io/
             if SQL.lower().startswith('select') or SQL.lower().startswith('pragma'):
 
                 # Make the query explicit so that column and table names are preserved
-                SQL, columns = self._explicit_query(SQL, use_converters=use_converters)
-
-                # Get the data as a dictionary
-                dictionary = self.dict(SQL, params).fetchall()
+                # Then, get the data as a dictionary
+                origSQL = SQL
+                try:
+                    SQL, columns = self._explicit_query(SQL, use_converters=use_converters)
+                    dictionary = self.dict(SQL, params).fetchall()
+                except:
+                    print('WARNING: Unable to use converters')
+                    dictionary = self.dict(origSQL, params).fetchall()
 
                 if any(dictionary):
 

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -100,8 +100,9 @@ class Database:
                 trigger_sql = os.popen(
                     """echo "SELECT sql FROM sqlite_master WHERE type='trigger' AND name LIKE '%insert%';" | sqlite3 {}"""
                         .format(self.dbpath)).read()
-                for trigger_name in trigger_names:
-                    os.system("""echo "DROP TRIGGER {};" | sqlite3 {}""".format(trigger_name, self.dbpath))
+                if len(trigger_names) > 0:
+                    for trigger_name in trigger_names:
+                        os.system("""echo "DROP TRIGGER {};" | sqlite3 {}""".format(trigger_name, self.dbpath))
 
                 # Then load the table data...
                 print('Populating database...')
@@ -114,10 +115,11 @@ class Database:
                     os.system('sqlite3 {0} ".read {1}/{2}.sql"'.format(self.dbpath, directory, table))
 
                 # Reactivate the INSERT triggers
-                for new_trigger in trigger_sql.split('END'):
-                    if new_trigger == '\n': continue
-                    # print(new_trigger + 'END;')
-                    os.system("""echo "{}" | sqlite3 {}""".format(new_trigger + 'END;', self.dbpath))
+                if len(trigger_sql) > 0:
+                    for new_trigger in trigger_sql.split('END'):
+                        if new_trigger == '\n': continue
+                        # print(new_trigger + 'END;')
+                        os.system("""echo "{}" | sqlite3 {}""".format(new_trigger + 'END;', self.dbpath))
 
             elif dbpath.endswith('.db'):
                 self.sqlpath = dbpath.replace('.db', '.sql')

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -93,6 +93,16 @@ class Database:
                 # First the schema...
                 os.system("sqlite3 {} < {}".format(self.dbpath, self.sqlpath))
 
+                # Prepare to deactivate the INSERT triggers (assumes these triggers are named with _insert)
+                trigger_names = os.popen(
+                    """echo "SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE '%insert%';" | sqlite3 {}"""
+                        .format(self.dbpath)).read().replace('\n', ' ').split()
+                trigger_sql = os.popen(
+                    """echo "SELECT sql FROM sqlite_master WHERE type='trigger' AND name LIKE '%insert%';" | sqlite3 {}"""
+                        .format(self.dbpath)).read()
+                for trigger_name in trigger_names:
+                    os.system("""echo "DROP TRIGGER {};" | sqlite3 {}""".format(trigger_name, self.dbpath))
+
                 # Then load the table data...
                 print('Populating database...')
                 # Grabbing only tables, not tables and views
@@ -102,6 +112,13 @@ class Database:
                 for table in tables:
                     print('Loading {}'.format(table))
                     os.system('sqlite3 {0} ".read {1}/{2}.sql"'.format(self.dbpath, directory, table))
+
+                # Reactivate the INSERT triggers
+                for new_trigger in trigger_sql.split('END'):
+                    if new_trigger == '\n': continue
+                    # print(new_trigger + 'END;')
+                    os.system("""echo "{}" | sqlite3 {}""".format(new_trigger + 'END;', self.dbpath))
+
             elif dbpath.endswith('.db'):
                 self.sqlpath = dbpath.replace('.db', '.sql')
                 self.dbpath = dbpath

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1525,7 +1525,7 @@ You can then issue a pull request on GitHub to have these changes reviewed and a
         except ValueError:
             print('Table {} not found'.format(table))
 
-    def search(self, criterion, table, columns='', fetch=False, radius=1/60.):
+    def search(self, criterion, table, columns='', fetch=False, radius=1/60., use_converters=False):
         """
         General search method for tables. For (ra,dec) input in decimal degrees,
         i.e. (12.3456,-65.4321), returns all sources within 1 arcminute, or the specified radius.
@@ -1545,7 +1545,8 @@ You can then issue a pull request on GitHub to have these changes reviewed and a
             Return the results of the query as an Astropy table
         radius: float
             Radius in degrees in which to search for objects if using (ra,dec). Default: 1/60 degree
-
+        use_converters: bool
+            Apply converters to columns with custom data types
         """
 
         # Get list of columns to search and format properly
@@ -1613,7 +1614,7 @@ You can then issue a pull request on GitHub to have these changes reviewed and a
                 q = "SELECT * FROM {} WHERE {}".format(table, ' OR '.join([r"REPLACE(" + c + r",' ','') like '%" \
                      + criterion.replace(' ', '') + r"%'" for c, t in zip(columns,types[np.in1d(columns, all_columns)]) \
                      if t == 'TEXT']))
-                results = self.query(q, fmt='table')
+                results = self.query(q, fmt='table', use_converters=use_converters)
             except:
                 print("Could not search {} table by string {}. Try again.".format(table.upper(), criterion))
 
@@ -1622,7 +1623,7 @@ You can then issue a pull request on GitHub to have these changes reviewed and a
             try:
                 q = "SELECT * FROM {} WHERE {}".format(table, ' OR '.join(['{}={}'.format(c, criterion) \
                      for c, t in zip(columns, types[np.in1d(columns, all_columns)]) if t == 'INTEGER']))
-                results = self.query(q, fmt='table')
+                results = self.query(q, fmt='table', use_converters=use_converters)
             except:
                 print("Could not search {} table by id {}. Try again.".format(table.upper(), criterion))
 

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -1622,7 +1622,12 @@ You can then issue a pull request on GitHub to have these changes reviewed and a
 
                     if sum(good) > 0:
                         params = ", ".join(['{}'.format(s) for s in df[good]['id'].tolist()])
-                        results = self.query('SELECT * FROM sources WHERE id IN ({})'.format(params), fmt='table')
+                        try:
+                            results = self.query('SELECT * FROM {} WHERE source_id IN ({})'.format(table, params),
+                                                 fmt='table')
+                        except:
+                            results = self.query('SELECT * FROM {} WHERE id IN ({})'.format(table, params),
+                                                 fmt='table')
             except:
                 print("Could not search {} table by coordinates {}. Try again.".format(table.upper(), criterion))
 

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -964,7 +964,7 @@ The full documentation can be found online at: http://astrodbkit.readthedocs.io/
 
     def merge(self, conflicted, tables=[], diff_only=True):
         """
-        Merges specific **tables** or all tables of **conflicted** databse into the master database.
+        Merges specific **tables** or all tables of **conflicted** database into the master database.
 
         Parameters
         ----------
@@ -1035,7 +1035,7 @@ The full documentation can be found online at: http://astrodbkit.readthedocs.io/
 
                     if data:
 
-                        # Just print(the table differences
+                        # Just print the table differences
                         if diff_only:
                             pprint(zip(*data)[1:], names=columns, title='New {} records'.format(table.upper()))
 
@@ -2172,7 +2172,7 @@ def pprint(data, names='', title='', formats={}):
     Parameters
     ----------
     data: (sequence, dict, table)
-        The data to print(in the table
+        The data to print in the table
     names: sequence
         The column names
     title: str (optional)

--- a/astrodbkit/astrodb.py
+++ b/astrodbkit/astrodb.py
@@ -93,12 +93,12 @@ class Database:
                 # First the schema...
                 os.system("sqlite3 {} < {}".format(self.dbpath, self.sqlpath))
 
-                # Prepare to deactivate the INSERT triggers (assumes these triggers are named with _insert)
+                # Prepare to deactivate the triggers (all, just in case)
                 trigger_names = os.popen(
-                    """echo "SELECT name FROM sqlite_master WHERE type='trigger' AND name LIKE '%insert%';" | sqlite3 {}"""
+                    """echo "SELECT name FROM sqlite_master WHERE type='trigger';" | sqlite3 {}"""
                         .format(self.dbpath)).read().replace('\n', ' ').split()
                 trigger_sql = os.popen(
-                    """echo "SELECT sql FROM sqlite_master WHERE type='trigger' AND name LIKE '%insert%';" | sqlite3 {}"""
+                    """echo "SELECT sql FROM sqlite_master WHERE type='trigger';" | sqlite3 {}"""
                         .format(self.dbpath)).read()
                 if len(trigger_names) > 0:
                     for trigger_name in trigger_names:
@@ -114,7 +114,7 @@ class Database:
                     print('Loading {}'.format(table))
                     os.system('sqlite3 {0} ".read {1}/{2}.sql"'.format(self.dbpath, directory, table))
 
-                # Reactivate the INSERT triggers
+                # Reactivate the triggers
                 if len(trigger_sql) > 0:
                     for new_trigger in trigger_sql.split('END'):
                         if new_trigger == '\n': continue

--- a/astrodbkit/tests/test_astrodb.py
+++ b/astrodbkit/tests/test_astrodb.py
@@ -32,6 +32,7 @@ def test_search():
     bdnyc_db.search('young', 'sources')
     bdnyc_db.search((222.106, 10.533), 'sources')
     bdnyc_db.search((338.673, 40.694), 'sources', radius=5)
+    bdnyc_db.search((338.673, 40.694), 'sources', radius=5, sql_search=True)
 
 
 def test_inventory():

--- a/astrodbkit/tests/test_astrodb.py
+++ b/astrodbkit/tests/test_astrodb.py
@@ -154,7 +154,6 @@ def test_references():
     bdnyc_db.references(id, column_name='publication_id')
 
 
-@pytest.mark.xfail
 def test_get_bibtex():
     bdnyc_db.get_bibtex(52)
     bdnyc_db.get_bibtex('Cruz03')

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 astropy
 matplotlib
 pandas
+requests

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,6 @@ setup(
     ],
     keywords='astrophysics',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-    install_requires=['numpy','astropy','matplotlib'],
+    install_requires=['numpy','astropy','matplotlib','requests','pandas'],
 
 )


### PR DESCRIPTION
A variety of small changes to astrodbkit. 
- Database.search() method now has an option to do sql-type box searches rather than the true angular separation in the interest of speed. The default option is to use the true angular separation.
- Added error handling in Database.query() to automatically set use_converters=False if it fails with True (the default). This can happen for complex queries.
- When creating the database with the SQL file, only tables are used for populating the database rather than both tables and views
- Testing now includes Python 3.6; Python 3.4 is allowed to fail.
- Added support for SQL triggers. INSERT triggers get deactivate when loading via the SQL file.
- Changed Database.search() so that when providing coordinates the table you indicated gets returned (eg, search for coordinates on the spectra table -> get results of the spectra table)

I have advanced the version to 0.6.4